### PR TITLE
Stop live555 logger from claiming it's backing up when it actually isn't

### DIFF
--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -21,4 +21,4 @@ jobs:
       run: ./genMakefiles linux
 
     - name: Make All live555 targets
-      run: make CPPFLAGS='-DLOG_FILE_TMP_DIR="\"/test/path\""'
+      run: make CPPFLAGS='-DDEBUG -DDEBUG_SEND'

--- a/UsageEnvironment/Log.cpp
+++ b/UsageEnvironment/Log.cpp
@@ -70,16 +70,15 @@ string LogLevelAsString(LogLevel logLevel) {
   }
 }
 
-void _Log::OutputToFile(const string filePath) {
-  currLogFilePath = filePath;
+_Log::_Log(const string logDirectory) : logLevel(LogLevelDebug) {
+  SetTmpLogDir(logDirectory);
 }
 
-void _Log::OutputToStdout(bool toStdout) {
-  logToStdout = toStdout;
-}
+void _Log::SetTmpLogDir(std::string logDirectory) {
+  lock_guard<mutex> changeTmpDirGuard(logMutex);
 
-_Log::_Log(const string logDirectory) : logFileDir(logDirectory), logToStdout(false), logLevel(LogLevelDebug) {
-  if (kMaxLogs == 0) {  // Use stdout
+  logFileDir = logDirectory;
+  if (kMaxLogs == 0 || logDirectory.empty()) {  // Use stdout
     currLogFilePath = "";
     logToStdout = true;
     return;
@@ -96,6 +95,8 @@ _Log::_Log(const string logDirectory) : logFileDir(logDirectory), logToStdout(fa
 
   // Set log file to 0 again
   SetLogFileNum(0);
+  logToStdout = false;
+  fflush(stdout);
 }
 
 // Caller assumed to be handling logMutex properly
@@ -113,6 +114,7 @@ FILE* _Log::AcquireFile() {
     }
     return logFileHandle;
   }
+  fflush(stdout);
 }
 
 void _Log::SetLogFileNum(unsigned int logNum) {
@@ -141,8 +143,14 @@ void _Log::NextLogFile() {
 
 void _Log::BackupLog(const string backupFilePath) {
   lock_guard<mutex> backupLockGuard(logMutex);
+
+  if (!logFileDir.empty()) {
+    printf("Cannot backup live555 logs as it is not enabled.\n");
+    return;
+  }
+
   if (access(backupFilePath.c_str(), F_OK) == 0 && remove(backupFilePath.c_str()) < 0) {
-    fprintf(stderr, "Couldn't remove old backup file in %s%s\n", backupFilePath, strerror(errno));
+    fprintf(stderr, "Couldn't remove old backup file in %s %s\n", backupFilePath.c_str(), strerror(errno));
     return;
   }
 

--- a/UsageEnvironment/include/Log.hh
+++ b/UsageEnvironment/include/Log.hh
@@ -46,9 +46,8 @@ public:
   ~_Log() {}
 
   void BackupLog(const std::string backupFileName);
-  void OutputToFile(const std::string filePath);
-  void OutputToStdout(bool toStdout);
   void SetLevel(LogLevel level);
+  void SetTmpLogDir(std::string logDirectory);
 
   void Panic(const std::string filePath, int line, const char* format, ...);
   void Fatal(const std::string filePath, int line, const char* format, ...);

--- a/testProgs/testH264VideoStreamer.cpp
+++ b/testProgs/testH264VideoStreamer.cpp
@@ -101,8 +101,6 @@ int main(int argc, char** argv) {
   *env << "Beginning streaming...\n";
   play();
 
-  Log.OutputToFile("/Users/adeel.abbas/Downloads/rtsp-issue/live555-logging/output.log");
-
   env->taskScheduler().doEventLoop(); // does not return
 
   return 0; // only to prevent compiler warning


### PR DESCRIPTION
Added a condition for backing up the logs (don't want to hard code the backup condition, will do that in the firmware repo), to prevent backup from occurring when it shouldn't. 