### PR TITLE
Report user agent name (client software)

### DIFF
--- a/liveMedia/RTSPServer.cpp
+++ b/liveMedia/RTSPServer.cpp
@@ -24,6 +24,8 @@ along with this library; if not, write to the Free Software Foundation, Inc.,
 #include "Base64.hh"
 #include <GroupsockHelper.hh>
 
+#define USER_AGENT_BUFFER_LENGTH 200
+
 ////////// RTSPServer implementation //////////
 
 RTSPServer*
@@ -1623,6 +1625,22 @@ void RTSPServer::RTSPClientSession
     }
     AddressString destAddrStr(destinationAddress);
     AddressString sourceAddrStr(sourceAddr);
+
+    // Extract and report the user agent name (client software)
+    char userAgentName[USER_AGENT_BUFFER_LENGTH] = {0};
+    const char* userAgentPrefix = "User-Agent: ";
+    const char* start = strstr(fFullRequestStr, userAgentPrefix);
+    if (start) {
+      start += strlen(userAgentPrefix);
+      const char* end = strpbrk(start, "\r\n");
+      size_t len = (end ? (size_t)(end - start) : strlen(start));
+      if (len > USER_AGENT_BUFFER_LENGTH - 1) {
+        len = USER_AGENT_BUFFER_LENGTH - 1;
+      }
+      memcpy(userAgentName, start, len);
+      userAgentName[len] = '\0';
+    }
+    subsession->notifyClientUserAgent(userAgentName, fOurSessionId);
 
     subsession->auditLog("START", destAddrStr.val(), fOurSessionId);
 

--- a/liveMedia/ServerMediaSession.cpp
+++ b/liveMedia/ServerMediaSession.cpp
@@ -437,6 +437,9 @@ Boolean ServerMediaSubsession::exceedsMaxStreams() {
 void ServerMediaSubsession::auditLog(const char* type, const char* address, u_int32_t session_id) {
 }
 
+void ServerMediaSubsession::notifyClientUserAgent(const char* userAgent, u_int32_t session_id) {
+}
+
 char const*
 ServerMediaSubsession::rangeSDPLine() const {
   // First, check for the special case where we support seeking by 'absolute' time:

--- a/liveMedia/include/ServerMediaSession.hh
+++ b/liveMedia/include/ServerMediaSession.hh
@@ -181,6 +181,7 @@ public:
 
   virtual Boolean exceedsMaxStreams();
   virtual void auditLog(const char* type, const char* address, u_int32_t session_id);
+  virtual void notifyClientUserAgent(const char* userAgent, u_int32_t session_id);
 
 protected: // we're a virtual base class
   ServerMediaSubsession(UsageEnvironment& env);


### PR DESCRIPTION
Extract "User-Agent" field from request header (which identifies the streaming client software) and report as part of ServerMediaSubsession.
